### PR TITLE
Vagrantfile update

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant::Config.run do |config|
 
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
-  config.vm.forward_port "http",  80,   8080
-  config.vm.forward_port "mysql", 3306, 3306
+  config.vm.forward_port 80,   8080  #http
+  config.vm.forward_port 3306, 3306  #mysql
 
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the


### PR DESCRIPTION
Vagrant no longer accepts names for port forwards.  It's a pretty simple fix, but this should make it easier for those getting started.

Thanks!
